### PR TITLE
Added support for Swift Packages

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,7 +9,8 @@ module.exports = {
             if (fileUri && fileUri.fsPath) {
                 const filePath = fileUri.fsPath;
                 const extname = path.extname(filePath);
-                if (extname === '.xcodeproj' || extname === '.xcworkspace') {
+                const basename = path.basename(filePath);
+                if (extname === '.xcodeproj' || extname === '.xcworkspace' || basename === 'Package.swift') {
                     const command = 'open -a Xcode ' + filePath;
                     child_process.exec(command, (error, stdout, stderr) => {
                         if (error) {


### PR DESCRIPTION
# About

Hey there. I tried your extension today and it works as expected with `*.xcodeproj` and `*.xcworkspace` but does not support `Package.swift`. 

Adding support looked pretty simple, though I'm not set up to test VSCode extensions I thought I'd give it a shot. 
Maybe the next time you are working in this repo you could give this PR a try. Or close it and move on with your life.  

# Changes
There are only 2 changes (1 really). 

We first grab the basename of the path (from what I can tell this should result in `Package.swift`)
```js
const basename = path.basename(filePath);
```

Then inspect the basename in your already existing check
```js
if (extname === '.xcodeproj' || extname === '.xcworkspace' || basename === 'Package.swift') {
```

I WAS able to test that `open -a Xcode` can handle a Swift packages (which it does) 
```sh
open -a Xcode "${SPM_PATH}/Package.swift" 
```


